### PR TITLE
Fix upstream github url for clash

### DIFF
--- a/nginx/common.conf
+++ b/nginx/common.conf
@@ -73,7 +73,7 @@ location /defaultusersecret/ {
 
   location /defaultusersecret/clash/ {
     #for clash configs
-    proxy_pass https://raw.githubusercontent.com/hiddify/config/main/clash/;
+    proxy_pass https://raw.githubusercontent.com/hiddify/hiddify-config/main/clash/;
     proxy_set_header Accept-Encoding "";
     proxy_set_header Connection "";
     sub_filter_once off;


### PR DESCRIPTION
I assume `hiddify/config` was the old name of the repo. The old URL sometimes works and sometimes not. Overall, better use the new/correct-as-of-now name.